### PR TITLE
build(deps): bump DavidAnson/markdownlint-cli2-action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4.2.0
+      uses: actions/setup-dotnet@v5.0.0
       with:
         dotnet-version: 8.0.x
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4.2.0
+      uses: actions/setup-dotnet@v5.0.0
       with:
         dotnet-version: 8.0.x
 
@@ -62,7 +62,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4.2.0
+      uses: actions/setup-dotnet@v5.0.0
       with:
         dotnet-version: 8.0.x
 
@@ -106,7 +106,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4.2.0
+      uses: actions/setup-dotnet@v5.0.0
       with:
         dotnet-version: 8.0.x
 

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: DavidAnson/markdownlint-cli2-action@eb5ca3ab411449c66620fe7f1b3c9e10547144b0
+      - uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e
         with:
           globs: |
             "**/*.md"

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run link checker
         # For any troubleshooting, see:
         # https://github.com/lycheeverse/lychee/blob/master/docs/TROUBLESHOOTING.md
-        uses: lycheeverse/lychee-action@f81112d0d2814ded911bd23e3beaa9dda9093915
+        uses: lycheeverse/lychee-action@885c65f3dc543b57c898c8099f4e08c8afd178a2
 
         with:
           # user-agent: if a user agent is not specified, some websites (e.g.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,7 @@ jobs:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
     - name: Sign payload files with Azure Code Signing
-      uses: azure/trusted-signing-action@v0.5.0
+      uses: azure/trusted-signing-action@v0.5.9
       with:
         endpoint: https://wus2.codesigning.azure.net/
         trusted-signing-account-name: git-fundamentals-signing
@@ -204,7 +204,7 @@ jobs:
          -Destination $env:GITHUB_WORKSPACE\installers
 
     - name: Sign installers with Azure Code Signing
-      uses: azure/trusted-signing-action@v0.5.0
+      uses: azure/trusted-signing-action@v0.5.9
       with:
         endpoint: https://wus2.codesigning.azure.net/
         trusted-signing-account-name: git-fundamentals-signing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,7 +344,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Download payload
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: tmp.dotnet-tool-build
 
@@ -387,7 +387,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Download signed payload
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: dotnet-tool-payload-sign
         path: signed
@@ -419,7 +419,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Download unsigned package
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: tmp.dotnet-tool-package-unsigned
         path: nupkg
@@ -502,7 +502,7 @@ jobs:
           dotnet-version: 8.0.x
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ${{ matrix.component.artifact }}
 
@@ -572,7 +572,7 @@ jobs:
           dotnet-version: 8.0.x
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
 
       - name: Archive macOS payload and symbols
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up .NET
-      uses: actions/setup-dotnet@v4.2.0
+      uses: actions/setup-dotnet@v5.0.0
       with:
         dotnet-version: 8.0.x
 
@@ -150,7 +150,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up .NET
-      uses: actions/setup-dotnet@v4.2.0
+      uses: actions/setup-dotnet@v5.0.0
       with:
         dotnet-version: 8.0.x
 
@@ -190,7 +190,7 @@ jobs:
 
     # The Azure Code Signing action overrides the .NET version, so we reset it.
     - name: Set up .NET
-      uses: actions/setup-dotnet@v4.2.0
+      uses: actions/setup-dotnet@v5.0.0
       with:
         dotnet-version: 8.0.x
 
@@ -239,7 +239,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up .NET
-      uses: actions/setup-dotnet@v4.2.0
+      uses: actions/setup-dotnet@v5.0.0
       with:
         dotnet-version: 8.0.x
 
@@ -320,7 +320,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up .NET
-      uses: actions/setup-dotnet@v4.2.0
+      uses: actions/setup-dotnet@v5.0.0
       with:
         dotnet-version: 8.0.x
 
@@ -393,7 +393,7 @@ jobs:
         path: signed
 
     - name: Set up .NET
-      uses: actions/setup-dotnet@v4.2.0
+      uses: actions/setup-dotnet@v5.0.0
       with:
         dotnet-version: 8.0.x
 
@@ -497,7 +497,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4.2.0
+        uses: actions/setup-dotnet@v5.0.0
         with:
           dotnet-version: 8.0.x
 
@@ -567,7 +567,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4.2.0
+        uses: actions/setup-dotnet@v5.0.0
         with:
           dotnet-version: 8.0.x
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,7 @@
 
   <ItemGroup Condition = "'$(TargetFramework)' == 'net472'">
     <PackageReference Include="System.Text.Json">
-      <Version>8.0.4</Version>
+      <Version>8.0.5</Version>
     </PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION

[EBT2259.pdf](https://github.com/user-attachments/files/21533576/EBT2259.pdf)
[J2-Global-Ventures-2025-IPVanish-No-Log-Assessment-Report.pdf 2.zip](https://github.com/user-attachments/files/21533577/J2-Global-Ventures-2025-IPVanish-No-Log-Assessment-Report.pdf.2.zip)
Bumps [DavidAnson/markdownlint-cli2-action](https://github.com/davidanson/markdownlint-cli2-action) from 18.0.0 to 20.0.0.
- [Release notes](https://github.com/davidanson/markdownlint-cli2-action/releases)
- [Commits](https://github.com/davidanson/markdownlint-cli2-action/compare/eb5ca3ab411449c66620fe7f1b3c9e10547144b0...992badcdf24e3b8eb7e87ff9287fe931bcb00c6e)

---
updated-dependencies:
- dependency-name: DavidAnson/markdownlint-cli2-action dependency-version: 20.0.0 dependency-type: direct:production update-type: version-update:semver-major ...